### PR TITLE
remove credentials from README

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
         id: toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-12-02
+          toolchain: nightly
           targets: "wasm32-unknown-unknown"
           components: "rustfmt"
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           cargo leptos build --release
           cargo lambda build --release --features=ssr --no-default-features
-          cargo lambda deploy --include target/site --enable-function-url
+          cargo lambda deploy --include target/site --enable-function-url | tail -n 1 >> $GITHUB_STEP_SUMMARY
         env:
           LEPTOS_OUTPUT_NAME: ${{ vars.LEPTOS_OUTPUT_NAME }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For a quick and dirty setup, you can:
 1. Create a new user in the IAM service (Access Management > Users)
 2. Click "Attach policies directly" on the "Set permissions" page
 3. Add the "AWSLambda_FullAccess" and "IAMFullAccess" policies, and complete the user creation
-4. Create an access key for the user (don't worry about the warning)
+4. Create an access key for the user, with "Use case" "Application running on an AWS compute service" (don't worry about the warning - just confirm)
 5. Place the access key and secret key in `~/.aws/credentials` (or wherever the
    appropriate location is for your system):
 
@@ -131,6 +131,20 @@ For a quick and dirty setup, you can:
 aws_access_key_id = ***************
 aws_secret_access_key = ***************
 ```
+
+
+To use Github Actions to deploy to AWS Lambda, add the following variables and secrets to Github by going to your repo's "Settings" > "Secrets and Variables" > "Actions"
+and enter in the following:
+
+Variables:
+
+- LEPTOS_OUTPUT_NAME - the name of your project, as in the `Cargo.toml` file
+- AWS_DEFAULT_REGION - the AWS region you want your Lambda deployed to, eg. `us-west-2`
+
+Secrets:
+
+- AWS_ACCESS_KEY_ID - from AWS IAM credentials
+- AWS_SECRET_ACCESS_KEY - the secret key associated with the Access Key, from the AWS IAM step (above)
 
 ### State
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ For a quick and dirty setup, you can:
 2. Click "Attach policies directly" on the "Set permissions" page
 3. Add the "AWSLambda_FullAccess" and "IAMFullAccess" policies, and complete the user creation
 4. Create an access key for the user, with "Use case" "Application running on an AWS compute service" (don't worry about the warning - just confirm)
-5. Save your credentials in a password manager or in a `~/.aws/credentials` file (or wherever the
-   appropriate location is for your system); your AWS access key and secret key will look similar to the (randomly generated) example, below.
+5. Save your credentials in an `~/.aws/credentials` file (or the appropriate location for your system, for `cargo-lambda` deployments),
+or store the credentials in a password manager for later setting up CI/CD deploys; your AWS access key and secret key will look similar to the (randomly generated) example, below.
 
 ```
 [default]

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ to generate a new project template.
 cd {{project-name}}
 ```
 
-to go to your newly created project.  
-Feel free to explore the project structure, but the best place to start with your application code is in `src/app.rs`.  
+to go to your newly created project.
+Feel free to explore the project structure, but the best place to start with your application code is in `src/app.rs`.
 Additionally, Cargo.toml may need updating as new versions of the dependencies are released, especially if things are not working after a `cargo update`.
 
 ## Running your project
@@ -68,7 +68,7 @@ cargo leptos end-to-end
 cargo leptos end-to-end --release
 ```
 
-Cargo-leptos uses Playwright as the end-to-end test tool.  
+Cargo-leptos uses Playwright as the end-to-end test tool.
 Tests are located in end2end/tests directory.
 
 ## Deploying Your Project
@@ -128,8 +128,8 @@ For a quick and dirty setup, you can:
 
 ```
 [default]
-aws_access_key_id = AKIAQYLPMN5HCTNK35FD
-aws_secret_access_key = rbWHpaI/lJnXdLteWHNnTVZpQztMB2+pdbb+KVgr
+aws_access_key_id = ***************
+aws_secret_access_key = ***************
 ```
 
 ### State

--- a/README.md
+++ b/README.md
@@ -123,15 +123,14 @@ For a quick and dirty setup, you can:
 2. Click "Attach policies directly" on the "Set permissions" page
 3. Add the "AWSLambda_FullAccess" and "IAMFullAccess" policies, and complete the user creation
 4. Create an access key for the user, with "Use case" "Application running on an AWS compute service" (don't worry about the warning - just confirm)
-5. Place the access key and secret key in `~/.aws/credentials` (or wherever the
-   appropriate location is for your system):
+5. Save your credentials in a password manager or in a `~/.aws/credentials` file (or wherever the
+   appropriate location is for your system); your AWS access key and secret key will look similar to the (randomly generated) example, below.
 
 ```
 [default]
-aws_access_key_id = ***************
-aws_secret_access_key = ***************
+aws_access_key_id = AKIAQYLPMN5HCTNK35FD
+aws_secret_access_key = rbWHpaI/lJnXdLteWHNnTVZpQztMB2+pdbb+KVgr
 ```
-
 
 To use Github Actions to deploy to AWS Lambda, add the following variables and secrets to Github by going to your repo's "Settings" > "Secrets and Variables" > "Actions"
 and enter in the following:


### PR DESCRIPTION
In this commit, I've removed the AWS credentials in the README.md; updated the `deploy.yml` github action so that it spits out the URL for the Lambda function when it's finished deploying, and added some instructions for adding variables and secrets for Github Actions.